### PR TITLE
Don't show keyboard on widget init

### DIFF
--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -454,7 +454,6 @@ class ChipsInputState<T> extends State<ChipsInput<T>> with TextInputClient {
     if (_textInputConnection?.attached ?? false) {
       _textInputConnection?.setEditingState(_value);
     }
-    _textInputConnection?.show();
   }
 
   @override


### PR DESCRIPTION
Fixes #13