### PR TITLE
More granular control of suggestions box

### DIFF
--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -68,7 +68,6 @@ class ChipsInput<T> extends StatefulWidget {
     this.userFocusNode,
     this.initialSuggestions,
     this.suggestionsBoxElevation = 0,
-    this.suggestionsBoxDecoration = const BoxDecoration(),
     this.suggestionsContainerPadding = EdgeInsets.zero,
     this.suggestionsContainerMargin = EdgeInsets.zero,
     this.suggestionsContainerDecoration = const BoxDecoration(),
@@ -144,9 +143,6 @@ class ChipsInput<T> extends StatefulWidget {
 
   /// Passed to `Material` as the `elevation` value for the overlay.
   final double suggestionsBoxElevation;
-
-  /// Decoration for the suggestions overlay.
-  final BoxDecoration suggestionsBoxDecoration;
 
   /// Padding for the suggestions overlay container.
   final EdgeInsets suggestionsContainerPadding;

--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -148,6 +148,18 @@ class ChipsInput<T> extends StatefulWidget {
   /// Decoration for the suggestions overlay.
   final BoxDecoration suggestionsBoxDecoration;
 
+  /// Padding for the suggestions overlay container.
+  final EdgeInsets suggestionsContainerPadding;
+
+  /// Margin for the suggestions overlay container.
+  final EdgeInsets suggestionsContainerMargin;
+
+  /// Decoration for the suggestions overlay container.
+  final BoxDecoration suggestionsContainerDecoration;
+
+  /// ClipBehavior for the suggestions overlay container.
+  final Clip suggestionsContainerClipBehavior;
+    
   /// Defines the keyboard focus for this widget.
   final FocusNode? userFocusNode;
 
@@ -288,18 +300,15 @@ class ChipsInputState<T> extends State<ChipsInput<T>> with TextInputClient {
             if (snapshot.hasData && snapshot.data!.isNotEmpty) {
               final suggestionsListView = Material(
                 elevation: widget.suggestionsBoxElevation,
-                child: ConstrainedBox(
-                  constraints: BoxConstraints(
-                    maxHeight: suggestionBoxHeight,
-                  ),
-                  child: DecoratedBox(
-                    decoration: widget.suggestionsBoxDecoration,
-                    child: Container(
+                child: Container(
                         padding:widget.suggestionsContainerPadding,
                         margin:widget.suggestionsContainerMargin,
                         decoration:widget.suggestionsContainerDecoration,
                         clipBehavior:widget.suggestionsContainerClipBehavior,
-                        child:ListView.builder(
+                        constraints: BoxConstraints(
+                            maxHeight: suggestionBoxHeight,
+                          ),
+                      child:ListView.builder(
                       shrinkWrap: true,
                       padding: EdgeInsets.zero,
                       itemCount: snapshot.data!.length,
@@ -313,9 +322,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>> with TextInputClient {
                             : Container();
                       },
                     ),
-                    ),
                   ),
-                ),
               );
               return Positioned(
                 width: size.width,

--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -69,6 +69,10 @@ class ChipsInput<T> extends StatefulWidget {
     this.initialSuggestions,
     this.suggestionsBoxElevation = 0,
     this.suggestionsBoxDecoration = const BoxDecoration(),
+    this.suggestionsContainerPadding = EdgeInsets.zero,
+    this.suggestionsContainerMargin = EdgeInsets.zero,
+    this.suggestionsContainerDecoration = const BoxDecoration(),
+    this.suggestionsContainerClipBehavior = Clip.none,
     this.showKeyboard = true,
   })  : assert(maxChips == null || initialValue.length <= maxChips),
         super(key: key);
@@ -290,7 +294,12 @@ class ChipsInputState<T> extends State<ChipsInput<T>> with TextInputClient {
                   ),
                   child: DecoratedBox(
                     decoration: widget.suggestionsBoxDecoration,
-                    child: ListView.builder(
+                    child: Container(
+                        padding:widget.suggestionsContainerPadding,
+                        margin:widget.suggestionsContainerPadding,
+                        decoration:widget.suggestionsContainerDecoration,
+                        clipBehavior:widget.suggestionsContainerClipBehavior,
+                        child:ListView.builder(
                       shrinkWrap: true,
                       padding: EdgeInsets.zero,
                       itemCount: snapshot.data!.length,
@@ -303,6 +312,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>> with TextInputClient {
                               )
                             : Container();
                       },
+                    ),
                     ),
                   ),
                 ),

--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -295,6 +295,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>> with TextInputClient {
           builder: (context, snapshot) {
             if (snapshot.hasData && snapshot.data!.isNotEmpty) {
               final suggestionsListView = Material(
+                color:Colors.transparent,
                 elevation: widget.suggestionsBoxElevation,
                 child: Container(
                         padding:widget.suggestionsContainerPadding,

--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -296,7 +296,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>> with TextInputClient {
                     decoration: widget.suggestionsBoxDecoration,
                     child: Container(
                         padding:widget.suggestionsContainerPadding,
-                        margin:widget.suggestionsContainerPadding,
+                        margin:widget.suggestionsContainerMargin,
                         decoration:widget.suggestionsContainerDecoration,
                         clipBehavior:widget.suggestionsContainerClipBehavior,
                         child:ListView.builder(


### PR DESCRIPTION
We need a lot more granular control over the suggestions box.  So it is now wrapped in a container with access to the various standard container variables.

The previous suggestionsBoxDecoration has been removed (and integrated into the new container) as its redundant.

TBH, the outer wrapping Material/elevation is also not ideal and should be part of this new container, but I left it there so as not to break peoples integrations too much